### PR TITLE
feat: revamp home & projects pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
             <a href="#" class="name">Evans Acheampong</a>
         </p>
         <p class="resume-wrap">
-            <button type="button" class="btn-text js-resume-btn">View resume</button>
+            <a href="./assets/resume.pdf" target="_blank" rel="noopener" class="btn-text">View resume</a>
         </p>
 
         <div class="block" id="now">
@@ -94,7 +94,8 @@
         <div class="footer-inner">
             <div class="footer-left">
                 <a href="https://github.com/evansachie" target="_blank" rel="noopener" class="footer-link">github.com/evansachie</a>
-                <span class="footer-meta">2026</span>
+                <span class="footer-sep">·</span>
+                <span class="footer-meta">© 2026</span>
             </div>
             <div class="footer-right">
                 <span class="footer-location">Accra; <span id="footerTime"></span></span>
@@ -107,23 +108,8 @@
         <a href="index.html" class="bottom-nav__link bottom-nav__link--active" aria-label="Home"><i class="fas fa-home"></i></a>
         <a href="projects.html" class="bottom-nav__link" aria-label="Projects"><i class="fas fa-folder-open"></i></a>
         <a href="index.html#contact" class="bottom-nav__link" aria-label="Contact"><i class="fas fa-envelope"></i></a>
-        <button type="button" class="bottom-nav__link js-resume-btn" aria-label="Resume"><i class="fas fa-file-alt"></i></button>
+        <a href="./assets/resume.pdf" target="_blank" rel="noopener" class="bottom-nav__link" aria-label="Resume"><i class="fas fa-file-alt"></i></a>
     </nav>
-
-    <div id="resumeModal" class="modal">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h3 class="modal-title">Resume</h3>
-                <div class="modal-header-actions">
-                    <a href="./assets/resume.pdf" target="_blank" rel="noopener" class="modal-open-pdf">Open in new tab</a>
-                    <button type="button" class="modal-close" aria-label="Close">×</button>
-                </div>
-            </div>
-            <div class="modal-body">
-                <embed src="./assets/resume.pdf" type="application/pdf" class="resume-pdf">
-            </div>
-        </div>
-    </div>
 
     <script src="script.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
         <div class="block" id="now">
             <p class="label">Now</p>
             <p class="prose">
-                SWE @ <a href="https://wewire.io" target="_blank" rel="noopener">WeWire</a>.
+                SWE @ <a href="https://www.wewire.com" target="_blank" rel="noopener">WeWire</a>.
                 New Grad in Computer Engineering from <a href="https://www.ug.edu.gh" target="_blank" rel="noopener">University of Ghana</a>.
             </p>
             <span class="emphasis">I like to do cool stuff with code...</span>
@@ -53,21 +53,21 @@
                 <div class="work-row">
                     <span class="work-date">Oct 2025 – Present</span>
                     <div class="work-details">
-                        <p class="work-line">Software Engineer at <a href="https://wewire.io" target="_blank" rel="noopener">WeWire</a></p>
+                        <p class="work-line">Software Engineer @ <a href="https://www.wewire.com" target="_blank" rel="noopener">WeWire</a></p>
                         <p class="work-meta">Accra, Hybrid.</p>
                     </div>
                 </div>
                 <div class="work-row">
-                    <span class="work-date">Jun 2025 – Oct 2025</span>
+                    <span class="work-date">Jun 2025 – Sep 2025</span>
                     <div class="work-details">
-                        <p class="work-line">Full Stack Developer at <a href="https://atlaslabsventures.com" target="_blank" rel="noopener">Atlas Labs Ventures</a></p>
+                        <p class="work-line">Full Stack Developer @ <a href="https://atlaslabsventures.com" target="_blank" rel="noopener">Atlas Labs Ventures</a></p>
                         <p class="work-meta">Contract.</p>
                     </div>
                 </div>
                 <div class="work-row">
-                    <span class="work-date">Jun 2024 – Jun 2025</span>
+                    <span class="work-date">Jun 2024 – May 2025</span>
                     <div class="work-details">
-                        <p class="work-line">Junior Software Engineer at <a href="https://digiits.com" target="_blank" rel="noopener">Digiits Agency</a></p>
+                        <p class="work-line">Junior Software Engineer @ <a href="https://digiits.com" target="_blank" rel="noopener">Digiits Agency</a></p>
                         <p class="work-meta">Accra, Hybrid.</p>
                     </div>
                 </div>
@@ -91,7 +91,7 @@
                 <span class="footer-meta">2025</span>
             </div>
             <div class="footer-right">
-                <span class="footer-location" id="footerLocation">Accra</span>
+                <span class="footer-location" id="footerLocation">Accra; </span>
             </div>
         </div>
     </footer>

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
             <div class="banner-overlay"></div>
         </div>
     </section>
+    <div class="page-wrap">
     <main class="main">
         <p class="name-wrap">
             <a href="#" class="name">Evans Acheampong</a>
@@ -32,7 +33,7 @@
             <p class="label">Now</p>
             <p class="prose">
                 SWE @ <a href="https://www.wewire.com" target="_blank" rel="noopener">WeWire</a>.
-                New Grad in Computer Engineering from <a href="https://www.ug.edu.gh" target="_blank" rel="noopener">University of Ghana</a>.
+                New Grad in Computer Engineering from <a href="https://www.ug.edu.gh" target="_blank" rel="noopener">Uni. of Ghana '25</a>.
             </p>
             <span class="emphasis">I like to do cool stuff with code...</span>
         </div>
@@ -43,6 +44,11 @@
                 Learning from others, innovating creatively, and exploring what’s possible with code.
                 Keen on full-stack development, UI/UX, and shipping things that matter.
             </p>
+        </div>
+
+        <div class="block block--tech">
+            <p class="label">Tech</p>
+            <p class="tech-stack">React · TypeScript · Node · Vue · NestJS · Express · PostgreSQL · Flutter · .NET · Figma</p>
         </div>
 
         <hr>
@@ -88,17 +94,17 @@
         <div class="footer-inner">
             <div class="footer-left">
                 <a href="https://github.com/evansachie" target="_blank" rel="noopener" class="footer-link">github.com/evansachie</a>
-                <span class="footer-meta">2025</span>
+                <span class="footer-meta">2026</span>
             </div>
             <div class="footer-right">
-                <span class="footer-location" id="footerLocation">Accra; </span>
+                <span class="footer-location">Accra; <span id="footerTime"></span></span>
             </div>
         </div>
     </footer>
+    </div>
 
     <nav class="bottom-nav" aria-label="Main navigation">
         <a href="index.html" class="bottom-nav__link bottom-nav__link--active" aria-label="Home"><i class="fas fa-home"></i></a>
-        <a href="index.html#work" class="bottom-nav__link" aria-label="Work"><i class="fas fa-briefcase"></i></a>
         <a href="projects.html" class="bottom-nav__link" aria-label="Projects"><i class="fas fa-folder-open"></i></a>
         <a href="index.html#contact" class="bottom-nav__link" aria-label="Contact"><i class="fas fa-envelope"></i></a>
         <button type="button" class="bottom-nav__link js-resume-btn" aria-label="Resume"><i class="fas fa-file-alt"></i></button>

--- a/projects.html
+++ b/projects.html
@@ -28,19 +28,26 @@
                 <div class="work-row work-row--no-date">
                     <div class="work-details">
                         <p class="work-line"><a href="https://yhelly.com" target="_blank" rel="noopener">YHelly</a></p>
-                        <p class="work-meta">Two-sided food marketplace. React, TypeScript, NestJS, PostgreSQL, Paystack.</p>
+                        <p class="work-meta">Two-sided food marketplace; React, TypeScript, NestJS, PostgreSQL, Paystack.</p>
                     </div>
                 </div>
                 <div class="work-row work-row--no-date">
                     <div class="work-details">
-                        <p class="work-line"><a href="https://lifeguard-vert.vercel.app" target="_blank" rel="noopener">LifeGuard</a></p>
-                        <p class="work-meta">Health and environmental monitoring. Flutter, React, .NET, PostgreSQL, ML.</p>
+                        <p class="work-line"><a href="https://lifeguard-vert.vercel.app" target="_blank" rel="noopener">LifeGuard</a> <a href="https://github.com/evansachie/LifeGuard" target="_blank" rel="noopener" class="work-gh">gh</a></p>
+                        <p class="work-meta">Health and environmental monitoring; Flutter, React, .NET, PostgreSQL, ML.</p>
                     </div>
                 </div>
                 <div class="work-row work-row--no-date">
                     <div class="work-details">
-                        <p class="work-line"><a href="https://uni-hive.vercel.app" target="_blank" rel="noopener">UniHive</a></p>
-                        <p class="work-meta">University task exchange across 8+ Ghanaian universities. React, Node, PostgreSQL, Paystack, Socket.io.</p>
+                        <p class="work-line"><a href="https://uni-hive.vercel.app" target="_blank" rel="noopener">UniHive</a> <a href="https://github.com/evansachie/UniHive" target="_blank" rel="noopener" class="work-gh">gh</a></p>
+                        <p class="work-meta">University task exchange across 8+ Ghanaian universities; React, Node, PostgreSQL, Paystack, Socket.io.</p>
+                    </div>
+                </div>
+
+                <div class="work-row work-row--no-date">
+                    <div class="work-details">
+                        <p class="work-line"><a href="https://fps-one.vercel.app/" target="_blank" rel="noopener">Filz Properties</a></p>
+                        <p class="work-meta">Real Estate Management System; React, Node, Express, MongoDB</p>
                     </div>
                 </div>
             </div>
@@ -84,7 +91,8 @@
         <div class="footer-inner">
             <div class="footer-left">
                 <a href="https://github.com/evansachie" target="_blank" rel="noopener" class="footer-link">github.com/evansachie</a>
-                <span class="footer-meta">2026</span>
+                <span class="footer-sep">·</span>
+                <span class="footer-meta">© 2026</span>
             </div>
             <div class="footer-right">
                 <span class="footer-location">Accra; <span id="footerTime"></span></span>
@@ -97,23 +105,8 @@
         <a href="index.html" class="bottom-nav__link" aria-label="Home"><i class="fas fa-home"></i></a>
         <a href="projects.html" class="bottom-nav__link bottom-nav__link--active" aria-label="Projects"><i class="fas fa-folder-open"></i></a>
         <a href="index.html#contact" class="bottom-nav__link" aria-label="Contact"><i class="fas fa-envelope"></i></a>
-        <button type="button" class="bottom-nav__link js-resume-btn" aria-label="Resume"><i class="fas fa-file-alt"></i></button>
+        <a href="./assets/resume.pdf" target="_blank" rel="noopener" class="bottom-nav__link" aria-label="Resume"><i class="fas fa-file-alt"></i></a>
     </nav>
-
-    <div id="resumeModal" class="modal">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h3 class="modal-title">Resume</h3>
-                <div class="modal-header-actions">
-                    <a href="./assets/resume.pdf" target="_blank" rel="noopener" class="modal-open-pdf">Open in new tab</a>
-                    <button type="button" class="modal-close" aria-label="Close">×</button>
-                </div>
-            </div>
-            <div class="modal-body">
-                <embed src="./assets/resume.pdf" type="application/pdf" class="resume-pdf">
-            </div>
-        </div>
-    </div>
 
     <script src="script.js"></script>
 </body>

--- a/projects.html
+++ b/projects.html
@@ -13,6 +13,13 @@
     <link href="style.css" rel="stylesheet">
 </head>
 <body>
+    <section class="banner-section" aria-hidden="true">
+        <div class="banner-wrap">
+            <img src="images/banner.jpg" alt="" class="banner">
+            <div class="banner-overlay"></div>
+        </div>
+    </section>
+    <div class="page-wrap">
     <main class="main main--page">
         <p class="label"><a href="index.html" class="back-link">← Home</a></p>
         <div class="block" id="projects">
@@ -39,23 +46,55 @@
             </div>
             <p class="link-more-wrap"><a href="https://github.com/evansachie?tab=repositories" target="_blank" rel="noopener" class="link-more">More on GitHub</a></p>
         </div>
+
+        <hr class="block-hr">
+
+        <div class="block" id="designs">
+            <p class="label">Designs</p>
+            <div class="project-list">
+                <div class="work-row work-row--no-date">
+                    <div class="work-details">
+                        <p class="work-line"><a href="https://www.figma.com/file/jWK0xJcNZk4r2kL8xfj0Vl/SKILLHUB" target="_blank" rel="noopener">SkillHub</a></p>
+                        <p class="work-meta">E-learning platform. Figma.</p>
+                    </div>
+                </div>
+                <div class="work-row work-row--no-date">
+                    <div class="work-details">
+                        <p class="work-line"><a href="https://www.figma.com/design/dxBKIDBjBaYjannJzO4Ffq/TERRA" target="_blank" rel="noopener">TERRA</a></p>
+                        <p class="work-meta">Rental platform for Ghana. Mobile-first, Figma.</p>
+                    </div>
+                </div>
+                <div class="work-row work-row--no-date">
+                    <div class="work-details">
+                        <p class="work-line"><a href="https://www.figma.com/design/6cbMQnPOWtgHCPsT9OZmKE/Troko" target="_blank" rel="noopener">Troko</a></p>
+                        <p class="work-meta">Logistics and cargo delivery. Requester, driver, admin. Figma.</p>
+                    </div>
+                </div>
+                <div class="work-row work-row--no-date">
+                    <div class="work-details">
+                        <p class="work-line"><a href="https://www.figma.com/file/8Bcyd0u3wEWXTygWfJ6Z36/StudentConnect" target="_blank" rel="noopener">StudentConnect</a></p>
+                        <p class="work-meta">Student platform, ride-sharing to campus events. Figma.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
     </main>
 
     <footer class="footer">
         <div class="footer-inner">
             <div class="footer-left">
                 <a href="https://github.com/evansachie" target="_blank" rel="noopener" class="footer-link">github.com/evansachie</a>
-                <span class="footer-meta">2025</span>
+                <span class="footer-meta">2026</span>
             </div>
             <div class="footer-right">
-                <span class="footer-location">Accra</span>
+                <span class="footer-location">Accra; <span id="footerTime"></span></span>
             </div>
         </div>
     </footer>
+    </div>
 
     <nav class="bottom-nav" aria-label="Main navigation">
         <a href="index.html" class="bottom-nav__link" aria-label="Home"><i class="fas fa-home"></i></a>
-        <a href="index.html#work" class="bottom-nav__link" aria-label="Work"><i class="fas fa-briefcase"></i></a>
         <a href="projects.html" class="bottom-nav__link bottom-nav__link--active" aria-label="Projects"><i class="fas fa-folder-open"></i></a>
         <a href="index.html#contact" class="bottom-nav__link" aria-label="Contact"><i class="fas fa-envelope"></i></a>
         <button type="button" class="bottom-nav__link js-resume-btn" aria-label="Resume"><i class="fas fa-file-alt"></i></button>

--- a/script.js
+++ b/script.js
@@ -5,6 +5,27 @@
   var resumeBtns = document.querySelectorAll(".js-resume-btn");
   var closeBtn = document.querySelector(".modal-close");
 
+  function formatTime(date) {
+    var h = date.getHours();
+    var m = date.getMinutes();
+    var s = date.getSeconds();
+    var ampm = h >= 12 ? "PM" : "AM";
+    h = h % 12 || 12;
+    m = m < 10 ? "0" + m : m;
+    s = s < 10 ? "0" + s : s;
+    return h + ":" + m + ":" + s + " " + ampm;
+  }
+
+  function updateFooterTime() {
+    var el = document.getElementById("footerTime");
+    if (el) el.textContent = formatTime(new Date());
+  }
+
+  updateFooterTime();
+  if (document.getElementById("footerTime")) {
+    setInterval(updateFooterTime, 1000);
+  }
+
   function openModal() {
     if (modal) {
       modal.style.display = "flex";

--- a/script.js
+++ b/script.js
@@ -1,10 +1,6 @@
 (function () {
   "use strict";
 
-  var modal = document.getElementById("resumeModal");
-  var resumeBtns = document.querySelectorAll(".js-resume-btn");
-  var closeBtn = document.querySelector(".modal-close");
-
   function formatTime(date) {
     var h = date.getHours();
     var m = date.getMinutes();
@@ -25,34 +21,6 @@
   if (document.getElementById("footerTime")) {
     setInterval(updateFooterTime, 1000);
   }
-
-  function openModal() {
-    if (modal) {
-      modal.style.display = "flex";
-      document.body.style.overflow = "hidden";
-    }
-  }
-
-  function closeModal() {
-    if (modal) {
-      modal.style.display = "none";
-      document.body.style.overflow = "";
-    }
-  }
-
-  resumeBtns.forEach(function (btn) {
-    btn.addEventListener("click", openModal);
-  });
-
-  if (closeBtn) closeBtn.addEventListener("click", closeModal);
-
-  window.addEventListener("click", function (e) {
-    if (e.target === modal) closeModal();
-  });
-
-  document.addEventListener("keydown", function (e) {
-    if (e.key === "Escape" && modal && modal.style.display === "flex") closeModal();
-  });
 
   document.querySelectorAll('a[href^="#"]').forEach(function (anchor) {
     anchor.addEventListener("click", function (e) {

--- a/style.css
+++ b/style.css
@@ -248,6 +248,19 @@ a:hover {
   color: var(--accent);
 }
 
+.work-gh {
+  font-weight: 400;
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  text-decoration: none;
+  margin-left: 0.5rem;
+}
+
+.work-gh:hover {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
 .work-meta {
   font-size: 0.875rem;
   color: var(--text-muted);
@@ -323,6 +336,12 @@ a:hover {
   text-decoration: underline;
 }
 
+.footer-sep {
+  color: var(--text-muted);
+  opacity: 0.6;
+  user-select: none;
+}
+
 .footer-meta {
   color: var(--text-muted);
   opacity: 0.85;
@@ -335,94 +354,6 @@ a:hover {
 
 .footer-location {
   color: var(--text-muted);
-}
-
-/* --- Modal --- */
-.modal {
-  display: none;
-  position: fixed;
-  z-index: 9999;
-  inset: 0;
-  background-color: rgba(0, 0, 0, 0.8);
-  align-items: center;
-  justify-content: center;
-  padding: 1.5rem;
-  box-sizing: border-box;
-}
-
-.modal-content {
-  display: flex;
-  flex-direction: column;
-  background: var(--bg-elevated);
-  width: 100%;
-  max-width: 900px;
-  height: 90vh;
-  max-height: 90vh;
-  border-radius: 12px;
-  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
-  overflow: hidden;
-}
-
-.modal-header {
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 1rem 1.25rem;
-  border-bottom: 1px solid var(--border);
-}
-
-.modal-title {
-  font-size: 1rem;
-  font-weight: 600;
-  color: var(--text);
-}
-
-.modal-header-actions {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}
-
-.modal-open-pdf {
-  font-size: 0.8125rem;
-  color: var(--accent);
-}
-
-.modal-open-pdf:hover {
-  color: var(--accent-hover);
-}
-
-.modal-close {
-  background: none;
-  border: none;
-  color: var(--text-muted);
-  font-size: 1.5rem;
-  line-height: 1;
-  cursor: pointer;
-  padding: 0.25rem;
-}
-
-.modal-close:hover {
-  color: var(--text);
-}
-
-.modal-body {
-  flex: 1;
-  min-height: 70vh;
-  overflow: auto;
-  background: #1a1a1a;
-  display: flex;
-  flex-direction: column;
-}
-
-.resume-pdf {
-  display: block;
-  width: 100%;
-  min-height: 70vh;
-  height: 100%;
-  border: none;
-  flex: 1;
 }
 
 @media (max-width: 640px) {
@@ -499,18 +430,24 @@ a:hover {
 .bottom-nav__link--active {
   background: var(--accent);
   color: #fff;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.25);
 }
 
 .bottom-nav__link--active:hover {
   background: var(--accent-hover);
   color: #fff;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.3);
 }
 
 .back-link {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
   color: var(--text-muted);
-  font-size: 0.875rem;
-  margin-bottom: 1rem;
+  margin-bottom: 1.25rem;
   display: inline-block;
+  text-decoration: none;
 }
 
 .back-link:hover {
@@ -518,5 +455,13 @@ a:hover {
 }
 
 .main--page {
-  padding-top: 2.5rem;
+  padding-top: 4rem;
+}
+
+.project-list .work-meta,
+.work-details .work-meta {
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+  margin-top: 0.15rem;
 }

--- a/style.css
+++ b/style.css
@@ -29,6 +29,15 @@ body {
   font-size: 1rem;
   -webkit-font-smoothing: antialiased;
   padding-bottom: 5rem;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.page-wrap {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
 }
 
 a {
@@ -89,7 +98,7 @@ a:hover {
 .banner-wrap {
   position: relative;
   width: 100%;
-  height: 260px;
+  height: 350px;
   overflow: hidden;
   -webkit-mask-image:
     linear-gradient(to bottom, black 0%, black 72%, transparent 100%),
@@ -245,6 +254,15 @@ a:hover {
   line-height: 1.5;
 }
 
+.tech-stack {
+  font-size: 0.875rem;
+  color: var(--text-muted);
+}
+
+.block-hr {
+  margin: 1.25rem 0 1.5rem;
+}
+
 .link-more-wrap {
   margin-top: 1rem;
 }
@@ -274,7 +292,7 @@ a:hover {
 .footer {
   border-top: 1px solid var(--border);
   padding: 1.25rem 1.5rem 2rem;
-  margin-top: 0.5rem;
+  margin-top: auto;
 }
 
 .footer-inner {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: mostly static HTML/CSS content and navigation changes, plus a small JS update for footer time display and removal of the resume modal behavior.
> 
> **Overview**
> **Revamps the portfolio UI/content on `index.html` and `projects.html`.** Adds a new *Tech* section on the home page, refreshes work/project details (dates/links), and introduces a *Designs* section plus an additional project and GitHub links on select projects.
> 
> **Simplifies resume and footer behavior.** Replaces the resume modal with direct links to `assets/resume.pdf`, removes the modal CSS/JS, updates the footer to show `© 2026` and a live `footerTime` clock, and adjusts layout/styling (sticky footer via `page-wrap`, taller banner, nav active styling, back-link styling).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f2302c7459e8a8e745e0386d0504f1a8242663f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->